### PR TITLE
feat(posts,comments): implement post and comment CRUD

### DIFF
--- a/backend/src/controllers/comment.controller.ts
+++ b/backend/src/controllers/comment.controller.ts
@@ -1,0 +1,65 @@
+import { Request, Response, NextFunction } from "express";
+import { z } from "zod";
+import * as commentService from "../services/comment.service";
+import { AppError } from "../middleware/error.middleware";
+
+const commentSchema = z.object({
+  content: z.string().min(1, "Comment cannot be empty").max(2000),
+});
+
+export async function addComment(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { content } = commentSchema.parse(req.body);
+    const comment = await commentService.createComment(
+      req.params.postId as string,
+      req.user!.userId,
+      content
+    );
+    res.status(201).json(comment);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new AppError(error.errors[0].message, 400, "VALIDATION_ERROR"));
+    } else {
+      next(error);
+    }
+  }
+}
+
+export async function getComments(req: Request, res: Response, next: NextFunction) {
+  try {
+    const cursor = req.query.cursor as string | undefined;
+    const limit = Math.min(parseInt(req.query.limit as string) || 5, 50);
+    const userId = req.user?.userId;
+    const result = await commentService.getComments(req.params.postId as string, cursor, limit, userId);
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function editComment(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { content } = commentSchema.parse(req.body);
+    const comment = await commentService.updateComment(
+      req.params.commentId as string,
+      req.user!.userId,
+      content
+    );
+    res.json(comment);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new AppError(error.errors[0].message, 400, "VALIDATION_ERROR"));
+    } else {
+      next(error);
+    }
+  }
+}
+
+export async function removeComment(req: Request, res: Response, next: NextFunction) {
+  try {
+    await commentService.deleteComment(req.params.commentId as string, req.user!.userId);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+}

--- a/backend/src/controllers/post.controller.ts
+++ b/backend/src/controllers/post.controller.ts
@@ -1,0 +1,94 @@
+import { Request, Response, NextFunction } from "express";
+import { z } from "zod";
+import * as postService from "../services/post.service";
+import { AppError } from "../middleware/error.middleware";
+
+// ── Validation Schemas ────────────────────────────────────
+const createPostSchema = z.object({
+  content: z.string().max(5000, "Post content is too long").optional().default(""),
+  imageUrl: z.string().url().optional(),
+  videoUrl: z.string().url().optional(),
+  visibility: z.enum(["PUBLIC", "FRIENDS", "PRIVATE"]).optional(),
+  sharedPostId: z.string().uuid().optional(),
+}).refine(
+  (data) => (data.content && data.content.trim().length > 0) || data.imageUrl || data.videoUrl || data.sharedPostId,
+  { message: "Post must have content, media, or a shared post.", path: ["content"] }
+);
+
+const updatePostSchema = z.object({
+  content: z.string().min(1).max(5000).optional(),
+  imageUrl: z.string().url().optional(),
+  videoUrl: z.string().url().optional(),
+  visibility: z.enum(["PUBLIC", "FRIENDS", "PRIVATE"]).optional(),
+});
+
+// ── Create Post ───────────────────────────────────────────
+export async function createPost(req: Request, res: Response, next: NextFunction) {
+  try {
+    const validated = createPostSchema.parse(req.body);
+    const post = await postService.createPost(req.user!.userId, validated);
+    res.status(201).json(post);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new AppError(error.errors[0].message, 400, "VALIDATION_ERROR"));
+    } else {
+      next(error);
+    }
+  }
+}
+
+// ── Get Post ──────────────────────────────────────────────
+export async function getPost(req: Request, res: Response, next: NextFunction) {
+  try {
+    const post = await postService.getPostById(req.params.postId as string, req.user!.userId);
+    res.json(post);
+  } catch (error) {
+    next(error);
+  }
+}
+
+// ── Update Post ───────────────────────────────────────────
+export async function updatePost(req: Request, res: Response, next: NextFunction) {
+  try {
+    const validated = updatePostSchema.parse(req.body);
+    const post = await postService.updatePost(
+      req.params.postId as string,
+      req.user!.userId,
+      validated
+    );
+    res.json(post);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new AppError(error.errors[0].message, 400, "VALIDATION_ERROR"));
+    } else {
+      next(error);
+    }
+  }
+}
+
+// ── Delete Post ───────────────────────────────────────────
+export async function deletePost(req: Request, res: Response, next: NextFunction) {
+  try {
+    await postService.deletePost(req.params.postId as string, req.user!.userId);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+}
+
+// ── Get User's Posts ──────────────────────────────────────
+export async function getUserPosts(req: Request, res: Response, next: NextFunction) {
+  try {
+    const cursor = req.query.cursor as string | undefined;
+    const limit = Math.min(parseInt(req.query.limit as string) || 10, 50);
+    const result = await postService.getUserPosts(
+      req.params.userId as string,
+      req.user!.userId,
+      cursor,
+      limit
+    );
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+}

--- a/backend/src/routes/comment.routes.ts
+++ b/backend/src/routes/comment.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { authenticate } from "../middleware/auth.middleware";
+import * as commentCtrl from "../controllers/comment.controller";
+
+// mergeParams: true lets us access :postId from the parent router
+const router = Router({ mergeParams: true });
+
+router.get("/", authenticate, commentCtrl.getComments);
+router.post("/", authenticate, commentCtrl.addComment);
+router.patch("/:commentId", authenticate, commentCtrl.editComment);
+router.delete("/:commentId", authenticate, commentCtrl.removeComment);
+
+export default router;

--- a/backend/src/routes/post.routes.ts
+++ b/backend/src/routes/post.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import { authenticate } from "../middleware/auth.middleware";
+import * as postCtrl from "../controllers/post.controller";
+
+const router = Router();
+
+// All post routes require authentication
+router.use(authenticate);
+
+router.post("/", postCtrl.createPost);
+router.get("/:postId", postCtrl.getPost);
+router.patch("/:postId", postCtrl.updatePost);
+router.delete("/:postId", postCtrl.deletePost);
+
+export default router;

--- a/backend/src/services/comment.service.ts
+++ b/backend/src/services/comment.service.ts
@@ -1,0 +1,140 @@
+import prisma from "../config/database";
+import { AppError } from "../middleware/error.middleware";
+import { createNotification } from "./notification.service";
+
+// Extract comment mapping to dynamic function
+export const getCommentSelect = (userId?: string) => ({
+  id: true,
+  content: true,
+  createdAt: true,
+  updatedAt: true,
+  authorId: true,
+  postId: true,
+  author: {
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      profilePicture: true,
+    },
+  },
+  _count: {
+    select: {
+      reactions: true,
+    },
+  },
+  ...(userId ? {
+    reactions: {
+      where: { userId },
+      select: { id: true },
+    }
+  } : {}),
+});
+
+// ── Create Comment ────────────────────────────────────────
+export async function createComment(postId: string, userId: string, content: string) {
+  // Verify the post exists
+  const post = await prisma.post.findUnique({ where: { id: postId } });
+  if (!post) throw new AppError("Post not found.", 404, "NOT_FOUND");
+
+  // Create comment and increment commentCount atomically
+  const [comment] = await prisma.$transaction([
+    prisma.comment.create({
+      data: { content, authorId: userId, postId },
+      select: getCommentSelect(userId),
+    }),
+    prisma.post.update({
+      where: { id: postId },
+      data: { commentCount: { increment: 1 } },
+    }),
+  ]);
+
+  // Notify the post author (unless they're commenting on their own post)
+  if (post.authorId !== userId) {
+    const actor = await prisma.user.findUnique({ where: { id: userId }, select: { firstName: true, lastName: true } });
+    if (actor) {
+      await createNotification(
+        post.authorId,
+        userId,
+        "COMMENT",
+        postId,
+        `${actor.firstName} ${actor.lastName} commented on your post.`
+      );
+    }
+  }
+
+  return comment;
+}
+
+// ── Get Comments for Post ─────────────────────────────────
+export async function getComments(
+  postId: string,
+  cursor?: string,
+  limit: number = 10,
+  userId?: string
+) {
+  const comments = await prisma.comment.findMany({
+    where: { postId },
+    select: getCommentSelect(userId),
+    orderBy: { createdAt: "asc" }, // Oldest first, like Facebook
+    take: limit + 1,
+    ...(cursor && { cursor: { id: cursor }, skip: 1 }),
+  });
+
+  const hasMore = comments.length > limit;
+  const items = hasMore ? comments.slice(0, limit) : comments;
+
+  const mappedItems = items.map((c: any) => {
+    const { reactions, ...rest } = c;
+    return {
+      ...rest,
+      hasReacted: reactions ? reactions.length > 0 : false,
+    };
+  });
+
+  return {
+    comments: mappedItems,
+    nextCursor: hasMore ? mappedItems[mappedItems.length - 1].id : null,
+    hasMore,
+  };
+}
+
+// ── Update Comment ────────────────────────────────────────
+export async function updateComment(commentId: string, userId: string, content: string) {
+  const comment = await prisma.comment.findUnique({
+    where: { id: commentId },
+    select: { authorId: true },
+  });
+
+  if (!comment) throw new AppError("Comment not found.", 404, "NOT_FOUND");
+  if (comment.authorId !== userId) {
+    throw new AppError("You can only edit your own comments.", 403, "FORBIDDEN");
+  }
+
+  return prisma.comment.update({
+    where: { id: commentId },
+    data: { content },
+    select: getCommentSelect(userId),
+  });
+}
+
+// ── Delete Comment ────────────────────────────────────────
+export async function deleteComment(commentId: string, userId: string) {
+  const comment = await prisma.comment.findUnique({
+    where: { id: commentId },
+    select: { authorId: true, postId: true },
+  });
+
+  if (!comment) throw new AppError("Comment not found.", 404, "NOT_FOUND");
+  if (comment.authorId !== userId) {
+    throw new AppError("You can only delete your own comments.", 403, "FORBIDDEN");
+  }
+
+  await prisma.$transaction([
+    prisma.comment.delete({ where: { id: commentId } }),
+    prisma.post.update({
+      where: { id: comment.postId },
+      data: { commentCount: { decrement: 1 } },
+    }),
+  ]);
+}

--- a/backend/src/services/post.service.ts
+++ b/backend/src/services/post.service.ts
@@ -1,0 +1,199 @@
+import { Visibility } from "@prisma/client";
+import prisma from "../config/database";
+import { AppError } from "../middleware/error.middleware";
+
+// ── Types ─────────────────────────────────────────────────
+interface CreatePostInput {
+  content?: string;
+  imageUrl?: string;
+  videoUrl?: string;
+  visibility?: Visibility;
+  sharedPostId?: string;
+}
+
+interface UpdatePostInput {
+  content?: string;
+  imageUrl?: string;
+  videoUrl?: string;
+  visibility?: Visibility;
+}
+
+// Reusable select — what fields to return for a post
+export const getPostSelect = (userId?: string) => ({
+  id: true,
+  content: true,
+  imageUrl: true,
+  videoUrl: true,
+  visibility: true,
+  likeCount: true,
+  commentCount: true,
+  shareCount: true,
+  createdAt: true,
+  updatedAt: true,
+  authorId: true,
+  author: {
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      profilePicture: true,
+    },
+  },
+  sharedPostId: true,
+  sharedPost: {
+    select: {
+      id: true,
+      content: true,
+      imageUrl: true,
+      videoUrl: true,
+      createdAt: true,
+      author: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          profilePicture: true,
+        }
+      }
+    }
+  },
+  ...(userId ? {
+    reactions: {
+      where: { userId },
+      select: { id: true },
+    }
+  } : {}),
+});
+
+// ── Create Post ───────────────────────────────────────────
+export async function createPost(userId: string, input: CreatePostInput) {
+  if (input.sharedPostId) {
+    await prisma.post.update({
+      where: { id: input.sharedPostId },
+      data: { shareCount: { increment: 1 } },
+    });
+  }
+
+  const post = await prisma.post.create({
+    data: {
+      content: input.content || "",
+      imageUrl: input.imageUrl || null,
+      videoUrl: input.videoUrl || null,
+      visibility: input.visibility || "PUBLIC",
+      authorId: userId,
+      sharedPostId: input.sharedPostId || null,
+    },
+    select: getPostSelect(userId),
+  });
+
+  const { reactions, ...rest } = post as any;
+  return { ...rest, hasReacted: reactions ? reactions.length > 0 : false };
+}
+
+// ── Get Single Post ───────────────────────────────────────
+export async function getPostById(postId: string, requesterId: string) {
+  const post = await prisma.post.findUnique({
+    where: { id: postId },
+    select: getPostSelect(requesterId),
+  });
+
+  if (!post) {
+    throw new AppError("Post not found.", 404, "NOT_FOUND");
+  }
+
+  // Visibility check
+  if (post.visibility === "PRIVATE" && post.authorId !== requesterId) {
+    throw new AppError("Post not found.", 404, "NOT_FOUND");
+  }
+
+  // FRIENDS visibility will be enforced once Friendship model is added
+  // For now, FRIENDS posts are visible to all authenticated users
+
+  const { reactions, ...rest } = post as any;
+  return { ...rest, hasReacted: reactions ? reactions.length > 0 : false };
+}
+
+// ── Update Post ───────────────────────────────────────────
+export async function updatePost(postId: string, userId: string, input: UpdatePostInput) {
+  // First check if the post exists and belongs to the user
+  const existingPost = await prisma.post.findUnique({
+    where: { id: postId },
+    select: { authorId: true },
+  });
+
+  if (!existingPost) {
+    throw new AppError("Post not found.", 404, "NOT_FOUND");
+  }
+
+  if (existingPost.authorId !== userId) {
+    throw new AppError("You can only edit your own posts.", 403, "FORBIDDEN");
+  }
+
+  const updated = await prisma.post.update({
+    where: { id: postId },
+    data: {
+      ...(input.content !== undefined && { content: input.content }),
+      ...(input.imageUrl !== undefined && { imageUrl: input.imageUrl }),
+      ...(input.videoUrl !== undefined && { videoUrl: input.videoUrl }),
+      ...(input.visibility !== undefined && { visibility: input.visibility }),
+    },
+    select: getPostSelect(userId),
+  });
+
+  const { reactions, ...rest } = updated as any;
+  return { ...rest, hasReacted: reactions ? reactions.length > 0 : false };
+}
+
+// ── Delete Post ───────────────────────────────────────────
+export async function deletePost(postId: string, userId: string) {
+  const existingPost = await prisma.post.findUnique({
+    where: { id: postId },
+    select: { authorId: true },
+  });
+
+  if (!existingPost) {
+    throw new AppError("Post not found.", 404, "NOT_FOUND");
+  }
+
+  if (existingPost.authorId !== userId) {
+    throw new AppError("You can only delete your own posts.", 403, "FORBIDDEN");
+  }
+
+  await prisma.post.delete({ where: { id: postId } });
+}
+
+// ── Get User's Posts ──────────────────────────────────────
+export async function getUserPosts(
+  userId: string,
+  requesterId: string,
+  cursor?: string,
+  limit: number = 10
+) {
+  const posts = await prisma.post.findMany({
+    where: {
+      authorId: userId,
+      // If not the author, hide PRIVATE posts
+      ...(userId !== requesterId && {
+        visibility: { not: "PRIVATE" },
+      }),
+    },
+    select: getPostSelect(requesterId),
+    orderBy: { createdAt: "desc" },
+    take: limit + 1, // Fetch one extra to check if there are more
+    ...(cursor && { cursor: { id: cursor }, skip: 1 }),
+  });
+
+  const hasMore = posts.length > limit;
+  const items = hasMore ? posts.slice(0, limit) : posts;
+
+  const mappedItems = items.map((post: any) => {
+    const { reactions, ...rest } = post;
+    return { ...rest, hasReacted: reactions ? reactions.length > 0 : false };
+  });
+
+  return {
+    posts: mappedItems,
+    nextCursor: hasMore ? mappedItems[mappedItems.length - 1].id : null,
+    hasMore,
+  };
+}


### PR DESCRIPTION
Posts:
- Create with content/media/visibility validation (requires content or media)
- Get single post with visibility enforcement (PRIVATE = author only)
- Update own post (content, media, visibility)
- Delete own post with ownership check
- Get user's posts with cursor-based pagination

Comments:
- Create comment with post existence check, atomic commentCount increment
- Notifies post author on new comment
- List comments with cursor pagination (oldest first)
- Edit/delete own comments with ownership checks
- Atomic commentCount decrement on delete