### PR TITLE
feat(reactions,feed): implement reaction toggle and algorithmic feed

### DIFF
--- a/backend/src/controllers/feed.controller.ts
+++ b/backend/src/controllers/feed.controller.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from "express";
+import * as feedService from "../services/feed.service";
+
+export async function getFeed(req: Request, res: Response, next: NextFunction) {
+  try {
+    const cursor = req.query.cursor as string | undefined;
+    const limit = Math.min(parseInt(req.query.limit as string) || 20, 50);
+    const seed = (req.query.seed as string) || "default_seed";
+    
+    const feed = await feedService.generateFeed(req.user!.userId, cursor, limit, seed);
+    res.json(feed);
+  } catch (error) {
+    next(error);
+  }
+}

--- a/backend/src/controllers/reaction.controller.ts
+++ b/backend/src/controllers/reaction.controller.ts
@@ -1,0 +1,51 @@
+import { Request, Response, NextFunction } from "express";
+import { z } from "zod";
+import * as reactionService from "../services/reaction.service";
+import { AppError } from "../middleware/error.middleware";
+
+const reactionSchema = z.object({
+  type: z.enum(["LIKE", "LOVE", "HAHA", "WOW", "SAD", "ANGRY"]),
+});
+
+// ── Post Reactions ─────────────────────────────────────────
+export async function reactToPost(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { type } = reactionSchema.parse(req.body);
+    const result = await reactionService.togglePostReaction(
+      req.params.postId as string,
+      req.user!.userId,
+      type
+    );
+    res.json(result);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new AppError(error.errors[0].message, 400, "VALIDATION_ERROR"));
+    } else next(error);
+  }
+}
+
+export async function getPostReactions(req: Request, res: Response, next: NextFunction) {
+  try {
+    const reactions = await reactionService.getPostReactions(req.params.postId as string);
+    res.json(reactions);
+  } catch (error) {
+    next(error);
+  }
+}
+
+// ── Comment Reactions ──────────────────────────────────────
+export async function reactToComment(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { type } = reactionSchema.parse(req.body);
+    const result = await reactionService.toggleCommentReaction(
+      req.params.commentId as string,
+      req.user!.userId,
+      type
+    );
+    res.json(result);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      next(new AppError(error.errors[0].message, 400, "VALIDATION_ERROR"));
+    } else next(error);
+  }
+}

--- a/backend/src/routes/feed.routes.ts
+++ b/backend/src/routes/feed.routes.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+import { authenticate } from "../middleware/auth.middleware";
+import { getFeed } from "../controllers/feed.controller";
+
+const router = Router();
+
+// GET /api/v1/feed
+router.get("/", authenticate, getFeed);
+
+export default router;

--- a/backend/src/routes/reaction.routes.ts
+++ b/backend/src/routes/reaction.routes.ts
@@ -1,0 +1,16 @@
+import { Router } from "express";
+import { authenticate } from "../middleware/auth.middleware";
+import * as reactionCtrl from "../controllers/reaction.controller";
+
+const router = Router();
+
+router.use(authenticate);
+
+// /posts/:postId/reactions
+router.post("/posts/:postId/reactions", reactionCtrl.reactToPost);
+router.get("/posts/:postId/reactions", reactionCtrl.getPostReactions);
+
+// /comments/:commentId/reactions
+router.post("/comments/:commentId/reactions", reactionCtrl.reactToComment);
+
+export default router;

--- a/backend/src/services/feed.service.ts
+++ b/backend/src/services/feed.service.ts
@@ -1,0 +1,57 @@
+import prisma from "../config/database";
+import { getPostSelect } from "./post.service";
+
+export async function generateFeed(userId: string, cursor?: string, limit: number = 20, seed: string = "default") {
+  // If cursor is provided, use it for cursor-based pagination
+  // Otherwise start from the beginning
+  const cursorClause = cursor
+    ? `AND "post_id" < ${`'${cursor}'`}`
+    : "";
+
+  // Use raw SQL to sort feed by Engagement Algorithm + Random Seed
+  const rawPosts = await prisma.$queryRawUnsafe<Array<{ id: string }>>(
+    `SELECT "post_id" as id,
+      (
+        (("like_count" * 1) + ("comment_count" * 2) + ("share_count" * 3) + 1)
+        / POW(EXTRACT(EPOCH FROM (NOW() - "created_at"))/3600 + 1, 1.5)
+      ) * (0.8 + (ABS(hashtext("post_id"::text || $2::text)) % 100) / 250.0) as score
+    FROM "posts"
+    WHERE ("visibility" = 'PUBLIC'::"visibility" OR "author_id" = $1)
+      ${cursorClause}
+    ORDER BY score DESC
+    LIMIT $3`,
+    userId,
+    seed,
+    limit + 1
+  );
+
+  const hasMore = rawPosts.length > limit;
+  const itemsIds = hasMore ? rawPosts.slice(0, limit) : rawPosts;
+  const ids = itemsIds.map(p => p.id);
+
+  if (ids.length === 0) {
+    return { posts: [], hasMore: false, nextCursor: null };
+  }
+
+  const posts = await prisma.post.findMany({
+    where: { id: { in: ids } },
+    select: getPostSelect(userId),
+  });
+
+  // Sort natively mapped result based on the raw ordered response IDs
+  const sortedPosts = ids.map(id => posts.find(p => p.id === id)).filter(Boolean);
+
+  const mappedItems = sortedPosts.map((post: any) => {
+    const { reactions, ...rest } = post;
+    return {
+      ...rest,
+      hasReacted: reactions ? reactions.length > 0 : false,
+    };
+  });
+
+  return {
+    posts: mappedItems,
+    nextCursor: hasMore ? mappedItems[mappedItems.length - 1].id : null,
+    hasMore,
+  };
+}

--- a/backend/src/services/reaction.service.ts
+++ b/backend/src/services/reaction.service.ts
@@ -1,0 +1,119 @@
+import { ReactionType } from "@prisma/client";
+import prisma from "../config/database";
+import { AppError } from "../middleware/error.middleware";
+import { createNotification } from "./notification.service";
+
+export async function togglePostReaction(postId: string, userId: string, type: ReactionType) {
+  // Check if post exists
+  const post = await prisma.post.findUnique({ where: { id: postId } });
+  if (!post) throw new AppError("Post not found.", 404, "NOT_FOUND");
+
+  // Check for existing reaction
+  const existing = await prisma.reaction.findUnique({
+    where: {
+      userId_postId: { userId, postId },
+    },
+  });
+
+  if (existing) {
+    if (existing.type === type) {
+      // Same reaction -> toggle off (delete) and decrement count
+      await prisma.$transaction([
+        prisma.reaction.delete({ where: { id: existing.id } }),
+        prisma.post.update({
+          where: { id: postId },
+          data: { likeCount: { decrement: 1 } },
+        }),
+      ]);
+      return { status: "removed" };
+    } else {
+      // Different reaction -> switch type (count stays same)
+      const updated = await prisma.reaction.update({
+        where: { id: existing.id },
+        data: { type },
+      });
+      return { status: "updated", reaction: updated };
+    }
+  } else {
+    // No reaction -> create and increment count
+    const [created, updatedPost] = await prisma.$transaction([
+      prisma.reaction.create({
+        data: { type, userId, postId },
+      }),
+      prisma.post.update({
+        where: { id: postId },
+        data: { likeCount: { increment: 1 } },
+      }),
+    ]);
+
+    if (updatedPost.authorId !== userId) {
+      const actor = await prisma.user.findUnique({ where: { id: userId }, select: { firstName: true, lastName: true } });
+      if (actor) {
+        await createNotification(
+          updatedPost.authorId,
+          userId,
+          "LIKE",
+          postId,
+          `${actor.firstName} ${actor.lastName} reacted to your post.`
+        );
+      }
+    }
+
+    return { status: "added", reaction: created };
+  }
+}
+
+export async function toggleCommentReaction(commentId: string, userId: string, type: ReactionType) {
+  // Similar logic for comments, but we aren't tracking a denormalized
+  // likeCount on comments right now (based on class diagram).
+  // If we decide to add comment like counts later, we update it here.
+
+  const comment = await prisma.comment.findUnique({ where: { id: commentId } });
+  if (!comment) throw new AppError("Comment not found.", 404, "NOT_FOUND");
+
+  const existing = await prisma.reaction.findUnique({
+    where: {
+      userId_commentId: { userId, commentId },
+    },
+  });
+
+  if (existing) {
+    if (existing.type === type) {
+      await prisma.reaction.delete({ where: { id: existing.id } });
+      return { status: "removed" };
+    } else {
+      const updated = await prisma.reaction.update({
+        where: { id: existing.id },
+        data: { type },
+      });
+      return { status: "updated", reaction: updated };
+    }
+  } else {
+    const created = await prisma.reaction.create({
+      data: { type, userId, commentId },
+    });
+
+    if (comment.authorId !== userId) {
+      const actor = await prisma.user.findUnique({ where: { id: userId }, select: { firstName: true, lastName: true } });
+      if (actor) {
+        // Find the parent post ID to link the notification correctly, or just link the comment
+        await createNotification(
+          comment.authorId,
+          userId,
+          "LIKE",
+          comment.postId,
+          `${actor.firstName} ${actor.lastName} reacted to your comment.`
+        );
+      }
+    }
+
+    return { status: "added", reaction: created };
+  }
+}
+
+export async function getPostReactions(postId: string) {
+  return prisma.reaction.findMany({
+    where: { postId },
+    include: { user: { select: { id: true, firstName: true, lastName: true } } },
+  });
+}


### PR DESCRIPTION
Reactions:
- Toggle behavior: same type = remove, different type = switch
- Polymorphic reactions on both posts and comments
- Atomic likeCount increment/decrement on posts
- Notifications to post/comment author on new reaction

Feed:
- Engagement-scored algorithm: (likes + comments*2 + shares*3) / time^1.5
- Randomized seed for feed variety
- Cursor-based pagination with nextCursor response
- Privacy filtering: PUBLIC posts + own PRIVATE posts