### PR TITLE
fix(postcard): route post author header clicks to profile page

### DIFF
--- a/frontend/src/components/PostCard.test.tsx
+++ b/frontend/src/components/PostCard.test.tsx
@@ -93,6 +93,22 @@ describe("PostCard owner actions", () => {
     expect(await screen.findByText("Edit page")).toBeInTheDocument();
   });
 
+  it("navigates to the author profile from the post header name", async () => {
+    render(
+      <AuthProvider>
+        <MemoryRouter initialEntries={["/feed"]}>
+          <Routes>
+            <Route path="/feed" element={<PostCard post={post} onPostDeleted={vi.fn()} />} />
+            <Route path="/profile/:userId" element={<div>Profile page</div>} />
+          </Routes>
+        </MemoryRouter>
+      </AuthProvider>
+    );
+
+    fireEvent.click(screen.getByText("Owner User"));
+    expect(await screen.findByText("Profile page")).toBeInTheDocument();
+  });
+
   it("aligns the floating menu with the post card content edge", async () => {
     const { container } = render(
       <AuthProvider>

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -270,7 +270,11 @@ export default function PostCard({
   return (
     <article ref={cardRef} className="post-card card" id={`post-${post.id}`}>
       <div className="post-header">
-        <div className="post-avatar">
+        <div
+          className="post-avatar"
+          onClick={() => navigate(`/profile/${post.author.id}`)}
+          style={{ cursor: "pointer" }}
+        >
           {post.author.profilePicture ? (
             <img src={post.author.profilePicture} alt={authorName} />
           ) : (
@@ -278,7 +282,13 @@ export default function PostCard({
           )}
         </div>
         <div className="post-meta">
-          <span className="post-author-name">{authorName}</span>
+          <span
+            className="post-author-name"
+            onClick={() => navigate(`/profile/${post.author.id}`)}
+            style={{ cursor: "pointer" }}
+          >
+            {authorName}
+          </span>
           <span className="post-time">
             {timeAgo(post.createdAt)} · <VisibilityIcon visibility={post.visibility} />
           </span>


### PR DESCRIPTION
- make the main post author name clickable and navigate to the author’s profile
- make the main post author avatar clickable and navigate to the author’s profile
- apply the fix in the shared `PostCard` component so it works in both feed and single-post views
- add a frontend regression test covering profile navigation from the post header